### PR TITLE
字: 截 由 甲 申 甴; 部: 亠

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 */.DS_Store
 scripts/.ipynb_checkpoints/*
 scripts/temp.yaml
+scripts/hanzi_chaizi*

--- a/scripts/standardize.ipynb
+++ b/scripts/standardize.ipynb
@@ -9,39 +9,62 @@
     "\n",
     "偏旁规范化，指的是让辅助码更符合 `zrm2000` 的映射规则，以此降低一个字同时对应多组辅助码的问题，从而减少重码。\n",
     "\n",
+    "- [**部首** 与 *偏旁* 的区别 --- 以'高'为例](http://www.xychild.com/zhongxiaoxue/shuokepingke/5750.html)\n",
+    "\n",
+    "- 如果一个字由部首(可以理解为\"主要\"的偏旁)和其它部分(也是偏旁), \"自然码+辅助码\"的第三码取做部首, 第四码取为最后一个偏旁.\n",
+    "\n",
+    "- 如果一个字本身就是部首, 即独体字, 不能进一步拆分出部件, 只能由笔画构成. \"自然码+辅助码\"的第三码是第一笔, 第四码是最后一笔.\n",
+    "\n",
     "`zrm2000` 的键位可参考以下链接：\n",
     "\n",
-    "1. https://www.liuchuo.net/archives/2847\n",
+    "1. [【双拼输入法】自然码辅助码入门教程（辅助码表）](https://www.liuchuo.net/archives/2847)\n",
     "\n",
-    "2. https://zhuanlan.zhihu.com/p/122866844\n",
+    "2. [双拼自然码辅助码方案及键位分布](https://zhuanlan.zhihu.com/p/122866844)\n",
     "\n",
-    "3. 键位图 https://blog.csdn.net/pmo992/article/details/104963648\n",
+    "3. [自然码辅助码键位图](https://blog.csdn.net/pmo992/article/details/104963648)\n",
     "\n",
     "\n",
-    "举个例子，我们这个方案默认的 `zrm-pinyin.dict.yaml` 里面如果存在同音多辅码的情况，比如说 `星` 字，有 `xy;ou` 和 `xy;ru` 两个码，则可以通过\n",
-    "\n",
+    "如果一个文件(比如 `zrm-pinyin.dict.yaml`) 存在一个字同一发音多个辅码的情况，比如说 `星` 字，有 `xy;ou` 和 `xy;ru` 两个码，则可以通过如下方法将辅助码统一到 `xy;ou`, 并且移除重复条目.\n",
+    " \n",
     "1. 用 `reShape` 函数对 `zrm-pinyin.dict.yaml` 操作 `xy;ru -> xy;ou`，输出至文件 `zrm-pinyin.temp.dict.yaml`。\n",
     "\n",
     "2. 用 `rmRepeat` 函数对 `zrm-pinyin.temp.dict.yaml` 操作干掉重复的 entry，输出至文件 `zrm-pinyin.wanted.dict.yaml`。\n",
     "\n",
-    "3. 备份原来的 `zrm-pinyin.dict.yaml`，再手动重命名 `zrm-pinyin.wanted.dict.yaml -> zrm-pinyin.dict.yaml` ，rime就会拿这个新文件当字典来用\n",
-    "\n",
-    "需要下载的外部 python package: \n",
-    "\n",
-    "1. [miaoluda/hanzi_chaizi forked from howl-anderson/hanzi_chaizi](https://github.com/miaoluda/hanzi_chaizi/tree/patch-1)。请注意要下载的是 fork 版 **不要下载原版** ，否则以下必报错"
+    "3. 备份原来的 `zrm-pinyin.dict.yaml`，再手动重命名 `zrm-pinyin.wanted.dict.yaml -> zrm-pinyin.dict.yaml` ，rime就会拿这个新文件当字典来用"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "385a18e4-c4f7-4cab-aa15-c644534c2566",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
+    "## 1. 拆字准备\n",
+    "\n",
+    "需要从 github 找以下内容, 打包 zip, 解压到 `scripts` 目录下, 并重命名文件夹为 `hanzi_chaizi`: \n",
+    "\n",
+    "1. [miaoluda/hanzi_chaizi forked from howl-anderson/hanzi_chaizi](https://github.com/miaoluda/hanzi_chaizi/tree/4d4307c7e2d760e8b2fee1b368f5e5939d3b9f5d). \n",
+    "\n",
     "导入 `sys`, `HanziChaizi` 并且熟悉后者的拆字逻辑。"
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "352aea38-1529-4085-99e3-6e2abcd80b9d",
+   "metadata": {},
+   "source": [
+    "### 1.1 有明显部首的字\n",
+    "\n",
+    "HanziChaizi 可以拆出大多数 *偏旁*, 但结果的第0个元素不一定是 **部首** :\n",
+    "\n",
+    "- '伍' 拆字之后的第0个元素是 '人', 是部首.\n",
+    "- '变' 拆字之后的第0个元素是 '亦', 是偏旁, *不是部首*."
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 6,
    "id": "df9974ad-8c29-4b70-8114-53003ed7155a",
    "metadata": {
     "tags": []
@@ -51,15 +74,17 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "['人', '五']\n"
+      "['人', '五']\n",
+      "['亦', '又']\n"
      ]
     }
    ],
    "source": [
     "import sys\n",
     "\n",
-    "# location of miaoluda/hanzi_chaizi package\n",
-    "sys.path.append(\"../../../hanzi_chaizi/\")\n",
+    "# 外部包 miaoluda/hanzi_chaizi 默认放到 scripts 目录之下\n",
+    "# 如果报错, 就把下面这行换成你下载的 miaoluda/hanzi_chaizi 的本地位置:\n",
+    "sys.path.append(\"./hanzi_chaizi\")\n",
     "from hanzi_chaizi import HanziChaizi\n",
     "\n",
     "hc = HanziChaizi()\n",
@@ -67,12 +92,49 @@
     "# 不要不加测试就盲目的拿 “亻” 去下面的代码 run，那样会毫无效果\n",
     "result = hc.query('伍')\n",
     "\n",
-    "print(result)"
+    "print(result)\n",
+    "print(hc.query('变'))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 7,
+   "id": "b58daf91-97e6-4c72-a102-8ede200b037b",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['肉', '旁']\n",
+      "['肉', '辟']\n",
+      "['敝', '目']\n",
+      "['手', '達']\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(hc.query('膀'))\n",
+    "print(hc.query('臂'))\n",
+    "print(hc.query('瞥'))\n",
+    "print(hc.query('撻'))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3a7e66c5-e27d-4e0b-a92b-93f18306d212",
+   "metadata": {},
+   "source": [
+    "### 1.2 独体字\n",
+    "一般是部首汉字，如：“金木水火土辶皿马皮日月目衣耳”等。独体字全部看成部首，不能进一步拆分出部件，只能由笔画构成。\n",
+    "对于这类字, 不要用 HanziChaizi 的结果!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
    "id": "dbdb4a4f-39b2-4eab-8432-11dd8437d815",
    "metadata": {
     "tags": []
@@ -84,7 +146,7 @@
        "['囗', '十']"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -98,12 +160,14 @@
    "id": "5646111e-1206-4dc5-b479-67ee09b92e1f",
    "metadata": {},
    "source": [
-    "”拆不动“的字，输出 `None`"
+    "### 1.3 ”拆不动“的字\n",
+    "\n",
+    "大部分为独体字或者 HanziChaizi 未收录的字, 输出 `None`"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "dce280d3-091f-4792-94b0-357e0a086d59",
    "metadata": {
     "tags": []
@@ -126,12 +190,12 @@
    "id": "0882ea00-3a57-49d5-9979-76cb6ec16b2a",
    "metadata": {},
    "source": [
-    "对一些极少使用的字有误伤，后果不严重。"
+    "对一些极少使用的字有误伤，但由于这些字使用频率很低, 后果不严重。"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 10,
    "id": "73e0c4e9-aff5-4677-8863-782bf3a04956",
    "metadata": {
     "tags": []
@@ -152,42 +216,22 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 22,
-   "id": "b58daf91-97e6-4c72-a102-8ede200b037b",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "['肉', '旁']\n",
-      "['肉', '辟']\n",
-      "['手', '達']\n"
-     ]
-    }
-   ],
-   "source": [
-    "print(hc.query('膀'))\n",
-    "print(hc.query('臂'))\n",
-    "print(hc.query('撻'))"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "id": "89e6fec3-5688-4fec-b77e-c6fb8c402d4e",
    "metadata": {},
    "source": [
-    "`reShape()` 函数用于规范化第三码（偏旁，也就是分号后面第一个辅助码），目前暂未考虑分号后面第二个辅助码，以后可能再出个 `reShape2()` 用来改进。\n",
+    "## 2. 构造用于分析文件的函数\n",
     "\n",
-    "`rmRepeat()` 函数用于去除“完全重复的编码”。"
+    "主要思路：for循环 + if条件判断。\n",
+    "\n",
+    "`reShape()` 函数用于规范化第三码(部首辅助码). 目前暂未考虑第四码, 因为\"最后一个偏旁\"很难从程序上消除模糊性, 为了避免更多的模棱两可, 所有字的第四码一律不做修改.\n",
+    "\n",
+    "`rmRepeat()` 函数用于去除相邻行且完全重复的编码条目。"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 11,
    "id": "f8a32974-dfd9-4970-afed-34ebaa69541f",
    "metadata": {
     "tags": []
@@ -195,43 +239,58 @@
    "outputs": [],
    "source": [
     "def reShape(src, temp):\n",
-    "    # 重新map辅助码。 \n",
+    "    # 重新map辅助码中的 部首 \n",
     "    # src: \"input dict\" ; dst: \"new file name for the output dict\"\n",
     "    with open(src, \"r\", encoding=\"utf-8\") as f1:\n",
     "        with open(temp, \"w\", encoding=\"utf-8\") as f2:\n",
     "            for line in f1:\n",
-    "                # NOTE: each line ends with a \\n , (possibly) except the last one.\n",
-    "                if '\\n' not in line:\n",
-    "                    line2 = line + '\\n'\n",
-    "                if line[0].isascii() or hc.query(line[0]) is None: # '\\n' belongs to ascii \n",
+    "                    \n",
+    "                # 如果缺失换行符 \\n，则添加 \\n.\n",
+    "                if '\\n' not in line: \n",
+    "                    line2 = line + '\\n'  \n",
+    "                \n",
+    "                # line[0] 不是汉字，或者“不能拆”\n",
+    "                if line[0].isascii() or hc.query(line[0]) is None: \n",
+    "                    # 该条件已包含以'\\n'开头的空行\n",
     "                    line2 = line\n",
-    "                elif ';r' in line:\n",
-    "                    if '彳' in hc.query(line[0])[0]:\n",
-    "                        # '行'字旁\n",
+    "                \n",
+    "                # line[0] 是“可以拆”的汉字，开始拆偏旁\n",
+    "                # line[5] 就是每行分号后的第一辅码（下称第三码）\n",
+    "                # 第三码为 ;r，则可能为 双立人，单立人，日，其他\n",
+    "                elif line[5]=='r':\n",
+    "                    # 判为'行'字旁(左)，第三码 r -> x\n",
+    "                    if hc.query(line[0])[0]=='彳':\n",
     "                        line2 = line.replace(';r', ';x')\n",
-    "                    elif '人' == hc.query(line[0])[0]:\n",
-    "                        # '人'字旁不变，还是原来的 r。\n",
-    "                        # 为了防止\"傝\"字（人-日-etc 结构）被改！\n",
+    "                    # 判为'人'字旁(左)，第三码原样输出 ;r。\n",
+    "                    # e.g. 为了防止\"傝\"字（ = 人+日+etc）被改成 ;o\n",
+    "                    elif hc.query(line[0])[0]=='人':\n",
     "                        line2 = line\n",
+    "                    # 判为'日'字旁，第三码 r -> o\n",
     "                    elif '日' in hc.query(line[0]):\n",
-    "                        # '日'字旁根据规则，是 o\n",
     "                        line2 = line.replace(';r', ';o')\n",
-    "                    else: # 剩下的 ;r 原样输出\n",
+    "                    # 剩下的 ;r 原样输出\n",
+    "                    else: \n",
     "                        line2 = line\n",
-    "                elif ';y' in line and '肉' in hc.query(line[0]):\n",
-    "                    # '月'字旁根据规则，是 o\n",
+    "                # 判为'月'字旁 第三码 y -> o\n",
+    "                elif line[5]=='y' and '肉' in hc.query(line[0]):\n",
     "                    line2 = line.replace(';y', ';o')\n",
-    "                elif ';m' in line and '目' in hc.query(line[0]):\n",
-    "                    # '目'字旁根据规则，是 o\n",
+    "                # 判为'目'字旁 第三码 m -> o\n",
+    "                elif line[5]=='m' and '目' in hc.query(line[0]):\n",
     "                    line2 = line.replace(';m', ';o')\n",
-    "                elif ';t' in line and '手' in hc.query(line[0]):\n",
-    "                    # 提'手'旁根据规则，是 f\n",
+    "                # 判为扶'手'旁(左) 第三码 t -> f\n",
+    "                elif line[5]=='t' and hc.query(line[0])[0]=='手':\n",
     "                    line2 = line.replace(';t', ';f')\n",
-    "                else: # 剩下的所有不关心的，原样输出\n",
+    "                # 判为'亠'旁(上) 第三码 d -> w\n",
+    "                elif line[5]=='d' and hc.query(line[0])[0]=='亠':\n",
+    "                    line2 = line.replace(';d', ';w')\n",
+    "                # 剩下的所有不关心的，原样输出\n",
+    "                else: \n",
     "                    line2 = line\n",
+    "                    \n",
     "                f2.write(line2)\n",
     "\n",
     "def reShape2(temp0, temp):\n",
+    "    # 计划整理第四码，not finished\n",
     "    pass\n",
     "                \n",
     "def rmRepeat(temp, dst):\n",
@@ -253,12 +312,12 @@
    "id": "46be5fce-106d-414b-818f-0c95ea888cf8",
    "metadata": {},
    "source": [
-    "实操环节："
+    "## 3. 分析文件"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 5,
    "id": "e3e7e3f8-b173-44fd-a7ad-041e03be5dba",
    "metadata": {
     "tags": []
@@ -266,20 +325,34 @@
    "outputs": [],
    "source": [
     "# temp.yaml 里面有“更符合规范”的码，但也有重复条目，因为 reShape() 没有删除任何一行！\n",
-    "reShape('../zrm_pinyin.utf8-lite.dict.yaml', \n",
-    "        'temp.yaml')   \n",
+    "reShape('../zrm_pinyin.standard_unique.dict.yaml', 'temp.yaml')   \n",
     "\n",
-    "# zrm_pinyin.output.dict.yaml 里面有“更符合规范”的码，且无重复条目\n",
-    "rmRepeat('temp.yaml', '../zrm_pinyin.standard_utf8_lite.dict.yaml')"
+    "# 去重, 并且(可选)覆盖原来的文件. 这样得到有“更符合规范”的码，且无重复条目\n",
+    "rmRepeat('temp.yaml', '../zrm_pinyin.standard_unique.dict.yaml')"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "54a99463-48c8-4a7c-a504-cda98e9dbbe5",
+   "cell_type": "markdown",
+   "id": "d90c95de-3148-4728-a8bf-3a149865259f",
    "metadata": {},
-   "outputs": [],
-   "source": []
+   "source": [
+    "经过上述过程, 第三码(部首/首个偏旁)得到了部分纠正, 而第四码(末个偏旁)未被调整. \n",
+    "\n",
+    "所以肯定仍然存在不准确的码. 欢迎提issue, 以便完善筛选部首的函数, 以及为第四码的错码找规律. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b3752ca7-1f6f-4a67-b275-e0bea113d763",
+   "metadata": {},
+   "source": [
+    "## 4. 可能有错的编码\n",
+    "\n",
+    "- 独体字, 如前所述, HanziChaizi 拆不准\n",
+    "    - 需要手动修改, 比如 '文', '方', '立' 等字, 应该按笔画拆分, 而不是提取 '亠' 作为部首.\n",
+    "- 生僻字, HanziChaizi 拆不了 (输出 None)\n",
+    "- 有部首的汉字, 但是拆错了部首. 比如\"仅\", 可能错把偏旁\"又\"当成了部首(正确的部首应该是\"人\")."
+   ]
   }
  ],
  "metadata": {

--- a/zrm_pinyin.standard_unique.dict.yaml
+++ b/zrm_pinyin.standard_unique.dict.yaml
@@ -7051,21 +7051,21 @@ use_preset_vocabulary: true
 亠	tb;wf
 亡	wh;dv	99.46%
 亡	wu;dv	0.54%
-亢	gh;dj	0%
-亢	kh;dj	100%
+亢	gh;wj	0%
+亢	kh;wj	100%
 亣	da;du
 亣	dl;du
 亣	tl;du
 交	jc;lw
-亥	hl;dd
+亥	hl;wd
 亦	yi;wb
 产	ij;li
 亨	hg;wl	100%
 亨	pg;wl	0%
-亩	mu;dt
+亩	mu;wt
 享	xd;wz
-京	jy;dx	100%
-京	yr;dx	0%
+京	jy;wx	100%
+京	yr;wx	0%
 亭	ty;wd
 亮	ld;wj
 亯	xd;wo
@@ -7076,14 +7076,14 @@ use_preset_vocabulary: true
 亲	qy;lm	0%
 亲	xn;lm	10%
 亲	vf;lm	90%
-亳	bo;dq
+亳	bo;wq
 亴	yb;wj
 亵	xx;yv
 亶	dj;wd
 亷	lm;lj
 亸	do;xd
-亹	mf;dq
-亹	wz;dq
+亹	mf;wq
+亹	wz;wq
 人	rf;pd
 亻	rf;rf
 亼	ji;rh
@@ -7907,7 +7907,7 @@ use_preset_vocabulary: true
 兂	zj;hg
 元	yr;ee
 兄	xs;ke
-充	is;dy
+充	is;wy
 兆	vk;ed
 兇	xs;ex
 先	xm;en
@@ -7961,8 +7961,8 @@ use_preset_vocabulary: true
 兪	yu;rd	100%
 八	ba;pd
 公	gs;bs
-六	lq;db	99.90%
-六	lu;db	0.10%
+六	lq;wb	99.90%
+六	lu;wb	0.10%
 兮	xi;bk
 兰	lj;bs
 共	gs;bc
@@ -8558,8 +8558,8 @@ use_preset_vocabulary: true
 协	xx;ub
 卐	wj;aa
 卑	bz;pu
-卒	cu;du	1.88%
-卒	zu;du	98.12%
+卒	cu;wu	1.88%
+卒	zu;wu	98.12%
 卓	vo;uo
 協	xx;ul
 单	ij;bd	0.10%
@@ -10524,8 +10524,6 @@ use_preset_vocabulary: true
 夙	su;jd
 多	do;xx
 夛	do;xa
-夜	ye;ww
-夜	ye;dw
 夜	ye;ww
 夝	qy;xu
 夞	wl;wi
@@ -13484,7 +13482,7 @@ use_preset_vocabulary: true
 戨	ge;gg
 戩	jm;gj
 戩	jn;gj
-截	jx;vg
+截	jx;gv
 戫	yu;yh
 戬	jm;gj
 戬	jn;gj
@@ -14777,9 +14775,7 @@ use_preset_vocabulary: true
 斶	iu;ju
 斷	dr;ja
 斸	vu;ji
-方	fh;dw
 方	fh;dp
-方	fh;dw
 斺	xx;fj
 斻	hh;fj
 斻	kh;fj
@@ -15879,7 +15875,7 @@ use_preset_vocabulary: true
 椈	ju;mj
 椉	ig;wj
 椉	ug;wm
-椉	ug;dj
+椉	ug;wj
 椉	ug;wm
 椊	cv;mz
 椊	zo;mz
@@ -19723,10 +19719,10 @@ use_preset_vocabulary: true
 甮	fs;wy
 甯	ny;by
 田	tm;aa
-由	yb;ur
-甲	jw;ru
-申	uf;oa
-甴	yb;uh
+由	yb;aa
+甲	jw;aa
+申	uf;aa
+甴	yb;aa
 甴	va;aa
 电	dm;ag
 甶	fu;pt
@@ -21136,8 +21132,8 @@ use_preset_vocabulary: true
 祾	lg;ul
 祾	ly;ul
 祿	lu;uu
-禀	bn;du
-禀	by;du
+禀	bn;wu
+禀	by;wu
 禀	ln;uh
 禁	jn;ul
 禂	dk;uv
@@ -27191,7 +27187,7 @@ use_preset_vocabulary: true
 豧	pu;uf
 豨	xi;ux
 豩	bn;uu
-豪	hk;du
+豪	hk;wu
 豫	yu;yx
 豬	vu;uv
 豭	jw;uj
@@ -31678,7 +31674,7 @@ use_preset_vocabulary: true
 髕	bn;gb
 髖	kr;gk
 髗	lu;gl
-高	gk;dk
+高	gk;wk
 髙	gk;wk
 髚	qc;gk
 髛	kk;gk
@@ -33041,10 +33037,10 @@ use_preset_vocabulary: true
 齇	va;bc
 齈	ns;bn
 齉	nh;bn
-齊	ji;de	0%
-齊	qi;de	100%
-齊	vl;de	0%
-齊	zi;de	0%
+齊	ji;we	0%
+齊	qi;we	100%
+齊	vl;we	0%
+齊	zi;we	0%
 齋	vl;wu
 齋	vl;dx
 齋	vl;wu
@@ -33053,12 +33049,12 @@ use_preset_vocabulary: true
 齍	ji;dm
 齍	zi;qm
 齎	ji;wb
-齏	ji;da
+齏	ji;wa
 齏	ji;qj
-齏	ji;da
-齏	jq;da
+齏	ji;wa
+齏	jq;wa
 齏	jq;qj
-齏	jq;da
+齏	jq;wa
 齐	ji;wp	0%
 齐	qi;wp	100%
 齐	vl;wp	0%

--- a/zrm_pinyin.standard_utf8_lite.dict.yaml
+++ b/zrm_pinyin.standard_utf8_lite.dict.yaml
@@ -7050,21 +7050,21 @@ min_phrase_weight: 100
 亠	tb;wf
 亡	wh;dv	99.46%
 亡	wu;dv	0.54%
-亢	gh;dj	0%
-亢	kh;dj	100%
+亢	gh;wj	0%
+亢	kh;wj	100%
 亣	da;du
 亣	dl;du
 亣	tl;du
 交	jc;lw
-亥	hl;dd
+亥	hl;wd
 亦	yi;wb
 产	ij;li
 亨	hg;wl	100%
 亨	pg;wl	0%
-亩	mu;dt
+亩	mu;wt
 享	xd;wz
-京	jy;dx	100%
-京	yr;dx	0%
+京	jy;wx	100%
+京	yr;wx	0%
 亭	ty;wd
 亮	ld;wj
 亯	xd;wo
@@ -7075,14 +7075,14 @@ min_phrase_weight: 100
 亲	qy;lm	0%
 亲	xn;lm	10%
 亲	vf;lm	90%
-亳	bo;dq
+亳	bo;wq
 亴	yb;wj
 亵	xx;yv
 亶	dj;wd
 亷	lm;lj
 亸	do;xd
-亹	mf;dq
-亹	wz;dq
+亹	mf;wq
+亹	wz;wq
 人	rf;pd
 亻	rf;rf
 亼	ji;rh
@@ -7906,7 +7906,7 @@ min_phrase_weight: 100
 兂	zj;hg
 元	yr;ee
 兄	xs;ke
-充	is;dy
+充	is;wy
 兆	vk;ed
 兇	xs;ex
 先	xm;en
@@ -7960,8 +7960,8 @@ min_phrase_weight: 100
 兪	yu;rd	100%
 八	ba;pd
 公	gs;bs
-六	lq;db	99.90%
-六	lu;db	0.10%
+六	lq;wb	99.90%
+六	lu;wb	0.10%
 兮	xi;bk
 兰	lj;bs
 共	gs;bc
@@ -8557,8 +8557,8 @@ min_phrase_weight: 100
 协	xx;ub
 卐	wj;aa
 卑	bz;pu
-卒	cu;du	1.88%
-卒	zu;du	98.12%
+卒	cu;wu	1.88%
+卒	zu;wu	98.12%
 卓	vo;uo
 協	xx;ul
 单	ij;bd	0.10%
@@ -10523,8 +10523,6 @@ min_phrase_weight: 100
 夙	su;jd
 多	do;xx
 夛	do;xa
-夜	ye;ww
-夜	ye;dw
 夜	ye;ww
 夝	qy;xu
 夞	wl;wi
@@ -13483,7 +13481,7 @@ min_phrase_weight: 100
 戨	ge;gg
 戩	jm;gj
 戩	jn;gj
-截	jx;vg
+截	jx;gv
 戫	yu;yh
 戬	jm;gj
 戬	jn;gj
@@ -14776,9 +14774,7 @@ min_phrase_weight: 100
 斶	iu;ju
 斷	dr;ja
 斸	vu;ji
-方	fh;dw
 方	fh;dp
-方	fh;dw
 斺	xx;fj
 斻	hh;fj
 斻	kh;fj
@@ -15878,7 +15874,7 @@ min_phrase_weight: 100
 椈	ju;mj
 椉	ig;wj
 椉	ug;wm
-椉	ug;dj
+椉	ug;wj
 椉	ug;wm
 椊	cv;mz
 椊	zo;mz
@@ -19722,10 +19718,10 @@ min_phrase_weight: 100
 甮	fs;wy
 甯	ny;by
 田	tm;aa
-由	yb;ur
-甲	jw;ru
-申	uf;oa
-甴	yb;uh
+由	yb;aa
+甲	jw;aa
+申	uf;aa
+甴	yb;aa
 甴	va;aa
 电	dm;ag
 甶	fu;pt
@@ -21135,8 +21131,8 @@ min_phrase_weight: 100
 祾	lg;ul
 祾	ly;ul
 祿	lu;uu
-禀	bn;du
-禀	by;du
+禀	bn;wu
+禀	by;wu
 禀	ln;uh
 禁	jn;ul
 禂	dk;uv
@@ -27190,7 +27186,7 @@ min_phrase_weight: 100
 豧	pu;uf
 豨	xi;ux
 豩	bn;uu
-豪	hk;du
+豪	hk;wu
 豫	yu;yx
 豬	vu;uv
 豭	jw;uj
@@ -31677,7 +31673,7 @@ min_phrase_weight: 100
 髕	bn;gb
 髖	kr;gk
 髗	lu;gl
-高	gk;dk
+高	gk;wk
 髙	gk;wk
 髚	qc;gk
 髛	kk;gk
@@ -33040,10 +33036,10 @@ min_phrase_weight: 100
 齇	va;bc
 齈	ns;bn
 齉	nh;bn
-齊	ji;de	0%
-齊	qi;de	100%
-齊	vl;de	0%
-齊	zi;de	0%
+齊	ji;we	0%
+齊	qi;we	100%
+齊	vl;we	0%
+齊	zi;we	0%
 齋	vl;wu
 齋	vl;dx
 齋	vl;wu
@@ -33052,12 +33048,12 @@ min_phrase_weight: 100
 齍	ji;dm
 齍	zi;qm
 齎	ji;wb
-齏	ji;da
+齏	ji;wa
 齏	ji;qj
-齏	ji;da
-齏	jq;da
+齏	ji;wa
+齏	jq;wa
 齏	jq;qj
-齏	jq;da
+齏	jq;wa
 齐	ji;wp	0%
 齐	qi;wp	100%
 齐	vl;wp	0%


### PR DESCRIPTION
- `zrm_pinyin.standard_unique.dict.yaml` & `zrm_pinyin.standard_utf8_lite.dict.yaml`
  - 截: `jx;gv` 部首为戈`g` 第四码为隹`v`
  - 由 甲 申 甴: 第三, 四码为 `;aa`, 因为这四个字均为独体字, 应该取第一笔和最后一笔. 第一笔竖, 最后一笔横/竖, 均为`a`.
  - 亠部首: 第三码为 `;w` (文)
- `scripts/standardize.ipynb`: 
   - if判断里面回归了亠部首: `;d -> ;w`; 
   - 修改文本, 解释了可能的误判或漏判